### PR TITLE
Adding skippedFails and undefinedFails as additional configurable vars

### DIFF
--- a/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
+++ b/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
@@ -40,6 +40,22 @@ public class CucumberReportGeneratorMojo extends AbstractMojo {
     private File cucumberOutput;
 
     /**
+     * Skipped fails
+     *
+     * @parameter expression="false"
+     * @required
+     */
+    private Boolean skippedFails;
+
+    /**
+     * Undefined fails
+     *
+     * @parameter expression="false"
+     * @required
+     */
+    private Boolean undefinedFails;
+
+    /**
      * Enable Flash Charts.
      *
      * @parameter expression="true"
@@ -58,7 +74,7 @@ public class CucumberReportGeneratorMojo extends AbstractMojo {
 
         try {
             System.out.println("About to generate");
-            reportBuilder = new ReportBuilder(list, outputDirectory, "", "1", projectName, false, false, enableFlashCharts, false, false, "");
+            reportBuilder = new ReportBuilder(list, outputDirectory, "", "1", projectName, skippedFails, undefinedFails, enableFlashCharts, false, false, "");
             reportBuilder.generateReports();
 
             boolean buildResult = reportBuilder.getBuildStatus();


### PR DESCRIPTION
This change will allow the user to configure the skippedFails and undefinedFails flags as necessary within their own pom.xml file. 

To be more clear, what I'm trying to achieve here is to have the HTML/Flash output display as failed when there are any pending or undefined steps. Currently it will show as all passed when no step definitions are provided.
