### PR TITLE
Returning failure behavior from what we expected in versions prior to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Run with: mvn verify
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <testFailureIgnore>true</testFailureIgnore>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>net.masterthought</groupId>
@@ -34,7 +37,8 @@ Run with: mvn verify
                                 <jsonFiles>
                                     <param>sample.json</param>
                                     <param>other.json</param>
-                                </jsonFiles>                                <parallelTesting>false</parallelTesting>
+                                </jsonFiles>
+                                <parallelTesting>false</parallelTesting>
                             </configuration>
                         </execution>
                     </executions>

--- a/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
+++ b/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
@@ -111,7 +111,7 @@ public class CucumberReportGeneratorMojo extends AbstractMojo {
             getLog().info("About to generate Cucumber report.");
             Reportable report = reportBuilder.generateReports();
 
-            if (checkBuildResult && report == null) {
+            if (checkBuildResult && (report == null || report.getFailedSteps() > 0)) {
                 throw new MojoExecutionException("BUILD FAILED - Check Report For Details");
             }
 


### PR DESCRIPTION
… 3.0.0. Now, if there is any Cucumber test failures, the build is broken when the flag checkBuildResult is set to true (default). Previous behavior in this case was the build only fails if the report is not generated.

This should fix issue #70 .