### PR TITLE
Add skip option to allow bypassing report generation entirely.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Run with: mvn verify
                             </goals>
                             <configuration>
                                 <projectName>cucumber-jvm-example</projectName>
+                                <!-- optional, defaults to false if not specified -->
+                                <skip>false</skip>
                                 <!-- output directory for the generated report -->
                                 <outputDirectory>${project.build.directory}</outputDirectory>
                                 <!-- optional, defaults to outputDirectory if not specified -->

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Run with: mvn verify
                             </goals>
                             <configuration>
                                 <projectName>cucumber-jvm-example</projectName>
-                                <!-- optional, defaults to false if not specified -->
+                                <!-- optional, per documentation set this to "true" to bypass generation of Cucumber Reports entirely, defaults to false if not specified -->
                                 <skip>false</skip>
                                 <!-- output directory for the generated report -->
                                 <outputDirectory>${project.build.directory}</outputDirectory>

--- a/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
+++ b/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
@@ -98,8 +98,20 @@ public class CucumberReportGeneratorMojo extends AbstractMojo {
      */
     private Map<String, String> classifications;
 
+    /**
+     * Set this to "true" to bypass generation of Cucumber Reports entirely.
+     *
+     * @parameter property="skip" default-value="false"
+     */
+    private boolean skip;
+
     @Override
     public void execute() throws MojoExecutionException {
+
+        if (skip) {
+            getLog().info("Cucumber report generation is skipped.");
+            return;
+        }
 
         if (inputDirectory == null) {
             inputDirectory = outputDirectory;

--- a/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
+++ b/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
@@ -101,7 +101,7 @@ public class CucumberReportGeneratorMojo extends AbstractMojo {
     /**
      * Set this to "true" to bypass generation of Cucumber Reports entirely.
      *
-     * @parameter property="skip" default-value="false"
+     * @parameter property="cucumber.report.skip" default-value="false"
      */
     private boolean skip;
 


### PR DESCRIPTION
Using similar mechanism as other Maven plugins (e.g. maven-surefire-plugin) to skip execution of the mojo.