### PR TITLE
Add control of treatment of Pending and Undefined steps on checkBuild…

### DIFF
--- a/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
+++ b/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
@@ -89,6 +89,20 @@ public class CucumberReportGeneratorMojo extends AbstractMojo {
     private Boolean checkBuildResult;
 
     /**
+     * Treat 'undefined' steps as failures when using checkBuildResult=true.
+     *
+     * @parameter default-value="false"
+     */
+    private Boolean treatUndefinedAsFailed;
+
+    /**
+     * Treat 'pending' steps as failures when using checkBuildResult=true.
+     *
+     * @parameter default-value="false"
+     */
+    private Boolean treatPendingAsFailed;
+
+    /**
      * Additional attributes to classify current test run.
      *
      * @parameter
@@ -154,7 +168,9 @@ public class CucumberReportGeneratorMojo extends AbstractMojo {
             getLog().info("About to generate Cucumber report.");
             Reportable report = reportBuilder.generateReports();
 
-            if (checkBuildResult && (report == null || report.getFailedSteps() > 0)) {
+            if (checkBuildResult && (report == null || report.getFailedSteps() > 0 ||
+                    (treatUndefinedAsFailed && report.getUndefinedSteps() > 0) ||
+                    (treatPendingAsFailed && report.getPendingSteps() > 0))) {
                 throw new MojoExecutionException("BUILD FAILED - Check Report For Details");
             }
 


### PR DESCRIPTION
…Result.

When running a build and relying upon checkBuildResult to mark pipeline failure, would like ability to have Pending or Undefined steps be treated as Failures with respect to pipeline results, rather than passes.
