### PR TITLE
Switch from back-ported Collections to the native import

### DIFF
--- a/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
+++ b/src/main/java/net/masterthought/cucumber/CucumberReportGeneratorMojo.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.ArrayUtils;


### PR DESCRIPTION
The back-ported Collections package is not available in a restricted env I'm trying to run in (doesn't have access to any public repo stores like maven central).
I assume this import was an accident when doing an auto-complete because the only place Collections is used is for an emptyList(), which the native one does implement. This fixes that.