### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,11 +177,7 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-        </dependency>
+        
         <dependency>
             <groupId>net.masterthought</groupId>
             <artifactId>cucumber-reporting</artifactId>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
maven-cucumber-reporting
{groupId='org.apache.maven.plugins', artifactId='maven-gpg-plugin'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
