### PR TITLE
Adopt removed unused parameter from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Run with: mvn verify
                                         <param>sample.properties</param>
                                         <param>other.properties</param>
                                 </classificationFiles>
-                                <parallelTesting>false</parallelTesting>
                                 <!-- optional, set true to group features by its Ids -->
                                 <mergeFeaturesById>false</mergeFeaturesById>
                                 <!-- optional, set true to get a final report with latest results of the same test from different test runs -->


### PR DESCRIPTION
This parameter has been originally removed by https://github.com/damianszczepanik/cucumber-reporting/pull/764 but was left within the README.md.

This small fix closes #167 